### PR TITLE
Use source branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To work properly delete created branches after merging them.
 
 ### `TARGET_BRANCH`
 
-**Required** The branchs you want to make the pull request to. Multiple branches need to be separate by comma like in example
+**Required** The branches you want to make the pull request to. Multiple branches need to be separated by comma like in example
 
 ## Outputs
 
@@ -27,6 +27,10 @@ Set to the URL of either the pull request that was opened by this action or the 
 ### `PULL_REQUEST_NUMBER`
 
 Pull request number from generated pull request or the currently open one
+
+### `PULL_REQUEST_NUMBER`
+
+The intermediate branch name used to create the pull request.
 
 ### Example
 

--- a/create-branch.js
+++ b/create-branch.js
@@ -1,15 +1,15 @@
-async function createBranch(octokit, context, branch) {
+async function createBranch(octokit, repo, sha, branch) {
   try {
     await octokit.repos.getBranch({
-      ...context.repo,
+      ...repo,
       branch,
     });
   } catch (error) {
     if (error.name === "HttpError" && error.status === 404) {
       await octokit.git.createRef({
         ref: `refs/heads/${branch}`,
-        sha: context.sha,
-        ...context.repo,
+        sha: sha,
+        ...repo,
       });
     } else {
       console.log("Error while creating new branch");

--- a/dist/index.js
+++ b/dist/index.js
@@ -505,7 +505,7 @@ module.exports = require("os");
 const core = __webpack_require__(470);
 const github = __webpack_require__(469);
 const createBranch = __webpack_require__(503);
-//
+
 async function run() {
   try {
     const sourceBranch = core.getInput("SOURCE_BRANCH", { required: true });
@@ -526,16 +526,24 @@ async function run() {
         owner: repository.owner.login,
         repo: repository.name,
       });
-      //create new branch from master branch and PR between new branch and target branch
+      //create new branch from source branch and PR between new branch and target branch
 
       const context = github.context;
-      const newBranch = `${branch}-sync-${context.sha.slice(-4)}`;
-      await createBranch(octokit, context, newBranch);
+      const {
+        data: { object: { sha } }
+      } = await octokit.git.getRef({
+        ref: `heads/${sourceBranch}`,
+        ...context.repo,
+      });
+      const newBranch = `${branch}-sync-${sha.slice(-4)}`;
+      console.log(`${sourceBranch} is at ${sha}. Intermediate branch for PR: ${newBranch}.`);
+      await createBranch(octokit, context.repo, sha, newBranch);
 
       const currentPull = currentPulls.find((pull) => {
         return pull.head.ref === newBranch && pull.base.ref === branch;
       });
 
+      core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {
         const { data: pullRequest } = await octokit.pulls.create({
           owner: repository.owner.login,
@@ -2087,7 +2095,7 @@ module.exports = require("https");
 /***/ 215:
 /***/ (function(module) {
 
-module.exports = {"_from":"@octokit/rest@^16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@types/node":"14.0.5","deprecation":"2.3.1","once":"1.4.0","os-name":"3.1.0"},"_requested":{"type":"range","registry":true,"raw":"@octokit/rest@^16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"^16.43.1","saveSpec":null,"fetchSpec":"^16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_shasum":"3b11e7d1b1ac2bbeeb23b08a17df0b20947eda6b","_spec":"@octokit/rest@^16.43.1","_where":"/home/bluesky/rahul/create-sync-pr/node_modules/@actions/github","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundleDependencies":false,"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"deprecated":false,"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
+module.exports = {"_args":[["@octokit/rest@16.43.1","/home/cognifloyd/g/github/cognifloyd/create-sync-pr.git"]],"_from":"@octokit/rest@16.43.1","_id":"@octokit/rest@16.43.1","_inBundle":false,"_integrity":"sha512-gfFKwRT/wFxq5qlNjnW2dh+qh74XgTQ2B179UX5K1HYCluioWj8Ndbgqw2PVqa1NnVJkGHp2ovMpVn/DImlmkw==","_location":"/@octokit/rest","_phantomChildren":{"@types/node":"14.0.5","deprecation":"2.3.1","once":"1.4.0","os-name":"3.1.0"},"_requested":{"type":"version","registry":true,"raw":"@octokit/rest@16.43.1","name":"@octokit/rest","escapedName":"@octokit%2frest","scope":"@octokit","rawSpec":"16.43.1","saveSpec":null,"fetchSpec":"16.43.1"},"_requiredBy":["/@actions/github"],"_resolved":"https://registry.npmjs.org/@octokit/rest/-/rest-16.43.1.tgz","_spec":"16.43.1","_where":"/home/cognifloyd/g/github/cognifloyd/create-sync-pr.git","author":{"name":"Gregor Martynus","url":"https://github.com/gr2m"},"bugs":{"url":"https://github.com/octokit/rest.js/issues"},"bundlesize":[{"path":"./dist/octokit-rest.min.js.gz","maxSize":"33 kB"}],"contributors":[{"name":"Mike de Boer","email":"info@mikedeboer.nl"},{"name":"Fabian Jakobs","email":"fabian@c9.io"},{"name":"Joe Gallo","email":"joe@brassafrax.com"},{"name":"Gregor Martynus","url":"https://github.com/gr2m"}],"dependencies":{"@octokit/auth-token":"^2.4.0","@octokit/plugin-paginate-rest":"^1.1.1","@octokit/plugin-request-log":"^1.0.0","@octokit/plugin-rest-endpoint-methods":"2.4.0","@octokit/request":"^5.2.0","@octokit/request-error":"^1.0.2","atob-lite":"^2.0.0","before-after-hook":"^2.0.0","btoa-lite":"^1.0.0","deprecation":"^2.0.0","lodash.get":"^4.4.2","lodash.set":"^4.3.2","lodash.uniq":"^4.5.0","octokit-pagination-methods":"^1.1.0","once":"^1.4.0","universal-user-agent":"^4.0.0"},"description":"GitHub REST API client for Node.js","devDependencies":{"@gimenete/type-writer":"^0.1.3","@octokit/auth":"^1.1.1","@octokit/fixtures-server":"^5.0.6","@octokit/graphql":"^4.2.0","@types/node":"^13.1.0","bundlesize":"^0.18.0","chai":"^4.1.2","compression-webpack-plugin":"^3.1.0","cypress":"^3.0.0","glob":"^7.1.2","http-proxy-agent":"^4.0.0","lodash.camelcase":"^4.3.0","lodash.merge":"^4.6.1","lodash.upperfirst":"^4.3.1","lolex":"^5.1.2","mkdirp":"^1.0.0","mocha":"^7.0.1","mustache":"^4.0.0","nock":"^11.3.3","npm-run-all":"^4.1.2","nyc":"^15.0.0","prettier":"^1.14.2","proxy":"^1.0.0","semantic-release":"^17.0.0","sinon":"^8.0.0","sinon-chai":"^3.0.0","sort-keys":"^4.0.0","string-to-arraybuffer":"^1.0.0","string-to-jsdoc-comment":"^1.0.0","typescript":"^3.3.1","webpack":"^4.0.0","webpack-bundle-analyzer":"^3.0.0","webpack-cli":"^3.0.0"},"files":["index.js","index.d.ts","lib","plugins"],"homepage":"https://github.com/octokit/rest.js#readme","keywords":["octokit","github","rest","api-client"],"license":"MIT","name":"@octokit/rest","nyc":{"ignore":["test"]},"publishConfig":{"access":"public"},"release":{"publish":["@semantic-release/npm",{"path":"@semantic-release/github","assets":["dist/*","!dist/*.map.gz"]}]},"repository":{"type":"git","url":"git+https://github.com/octokit/rest.js.git"},"scripts":{"build":"npm-run-all build:*","build:browser":"npm-run-all build:browser:*","build:browser:development":"webpack --mode development --entry . --output-library=Octokit --output=./dist/octokit-rest.js --profile --json > dist/bundle-stats.json","build:browser:production":"webpack --mode production --entry . --plugin=compression-webpack-plugin --output-library=Octokit --output-path=./dist --output-filename=octokit-rest.min.js --devtool source-map","build:ts":"npm run -s update-endpoints:typescript","coverage":"nyc report --reporter=html && open coverage/index.html","generate-bundle-report":"webpack-bundle-analyzer dist/bundle-stats.json --mode=static --no-open --report dist/bundle-report.html","lint":"prettier --check '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","lint:fix":"prettier --write '{lib,plugins,scripts,test}/**/*.{js,json,ts}' 'docs/*.{js,json}' 'docs/src/**/*' index.js README.md package.json","postvalidate:ts":"tsc --noEmit --target es6 test/typescript-validate.ts","prebuild:browser":"mkdirp dist/","pretest":"npm run -s lint","prevalidate:ts":"npm run -s build:ts","start-fixtures-server":"octokit-fixtures-server","test":"nyc mocha test/mocha-node-setup.js \"test/*/**/*-test.js\"","test:browser":"cypress run --browser chrome","update-endpoints":"npm-run-all update-endpoints:*","update-endpoints:fetch-json":"node scripts/update-endpoints/fetch-json","update-endpoints:typescript":"node scripts/update-endpoints/typescript","validate:ts":"tsc --target es6 --noImplicitAny index.d.ts"},"types":"index.d.ts","version":"16.43.1"};
 
 /***/ }),
 
@@ -7522,18 +7530,18 @@ exports.RequestError = RequestError;
 /***/ 503:
 /***/ (function(module) {
 
-async function createBranch(octokit, context, branch) {
+async function createBranch(octokit, repo, sha, branch) {
   try {
     await octokit.repos.getBranch({
-      ...context.repo,
+      ...repo,
       branch,
     });
   } catch (error) {
     if (error.name === "HttpError" && error.status === 404) {
       await octokit.git.createRef({
         ref: `refs/heads/${branch}`,
-        sha: context.sha,
-        ...context.repo,
+        sha: sha,
+        ...repo,
       });
     } else {
       console.log("Error while creating new branch");

--- a/dist/index.js
+++ b/dist/index.js
@@ -554,7 +554,7 @@ async function run() {
         });
 
         console.log(
-          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.url}.`
+          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.html_url}`
         );
 
         core.setOutput("PULL_REQUEST_URL", pullRequest.url.toString());

--- a/dist/index.js
+++ b/dist/index.js
@@ -531,13 +531,16 @@ async function run() {
         ref: `heads/${sourceBranch}`,
         ...context.repo,
       });
+      console.log(`${sourceBranch} is at ${sha}.`);
+
       const newBranch = `${branch}-sync-${sha.slice(-4)}`;
-      console.log(`${sourceBranch} is at ${sha}. Intermediate branch for PR: ${newBranch}.`);
       await createBranch(octokit, context.repo, sha, newBranch);
+      console.log(`Intermediate branch for PR: ${newBranch}.`);
 
       const currentPull = currentPulls.find((pull) => {
         return pull.head.ref === newBranch && pull.base.ref === branch;
       });
+      console.log(`currentPull: ${currentPull}`);
 
       core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -516,19 +516,15 @@ async function run() {
 
     for (let branch of targetBranchesArray) {
       console.log(`Making a pull request for ${branch} from ${sourceBranch}.`);
-      const {
-        payload: { repository },
-      } = github.context;
+      const context = github.context;
 
       const octokit = new github.GitHub(githubToken);
       //part of test
       const { data: currentPulls } = await octokit.pulls.list({
-        owner: repository.owner.login,
-        repo: repository.name,
+        ...context.repo,
       });
       //create new branch from source branch and PR between new branch and target branch
 
-      const context = github.context;
       const {
         data: { object: { sha } }
       } = await octokit.git.getRef({
@@ -546,13 +542,12 @@ async function run() {
       core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {
         const { data: pullRequest } = await octokit.pulls.create({
-          owner: repository.owner.login,
-          repo: repository.name,
           head: newBranch,
           base: branch,
           title: `sync: ${branch}  with ${newBranch}`,
           body: `sync-branches: syncing branch with ${newBranch}`,
           draft: false,
+          ...context.repo,
         });
 
         console.log(

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function run() {
         });
 
         console.log(
-          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.url}.`
+          `Pull request (${pullRequest.number}) successful! You can view it here: ${pullRequest.html_url}`
         );
 
         core.setOutput("PULL_REQUEST_URL", pullRequest.url.toString());

--- a/index.js
+++ b/index.js
@@ -25,8 +25,9 @@ async function run() {
       //create new branch from master branch and PR between new branch and target branch
 
       const context = github.context;
-      const newBranch = `${branch}-sync-${context.sha.slice(-4)}`;
-      await createBranch(octokit, context, newBranch);
+	  const sha = context.sha;
+      const newBranch = `${branch}-sync-${sha.slice(-4)}`;
+      await createBranch(octokit, context.repo, sha, newBranch);
 
       const currentPull = currentPulls.find((pull) => {
         return pull.head.ref === newBranch && pull.base.ref === branch;

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ async function run() {
         return pull.head.ref === newBranch && pull.base.ref === branch;
       });
 
+      core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {
         const { data: pullRequest } = await octokit.pulls.create({
           owner: repository.owner.login,

--- a/index.js
+++ b/index.js
@@ -27,13 +27,16 @@ async function run() {
         ref: `heads/${sourceBranch}`,
         ...context.repo,
       });
+      console.log(`${sourceBranch} is at ${sha}.`);
+
       const newBranch = `${branch}-sync-${sha.slice(-4)}`;
-      console.log(`${sourceBranch} is at ${sha}. Intermediate branch for PR: ${newBranch}.`);
       await createBranch(octokit, context.repo, sha, newBranch);
+      console.log(`Intermediate branch for PR: ${newBranch}.`);
 
       const currentPull = currentPulls.find((pull) => {
         return pull.head.ref === newBranch && pull.base.ref === branch;
       });
+      console.log(`currentPull: ${currentPull}`);
 
       core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {

--- a/index.js
+++ b/index.js
@@ -22,11 +22,17 @@ async function run() {
         owner: repository.owner.login,
         repo: repository.name,
       });
-      //create new branch from master branch and PR between new branch and target branch
+      //create new branch from source branch and PR between new branch and target branch
 
       const context = github.context;
-	  const sha = context.sha;
+      const {
+        data: { object: { sha } }
+      } = await octokit.git.getRef({
+        ref: `heads/${sourceBranch}`,
+        ...context.repo,
+      });
       const newBranch = `${branch}-sync-${sha.slice(-4)}`;
+      console.log(`${sourceBranch} is at ${sha}. Intermediate branch for PR: ${newBranch}.`);
       await createBranch(octokit, context.repo, sha, newBranch);
 
       const currentPull = currentPulls.find((pull) => {

--- a/index.js
+++ b/index.js
@@ -12,19 +12,15 @@ async function run() {
 
     for (let branch of targetBranchesArray) {
       console.log(`Making a pull request for ${branch} from ${sourceBranch}.`);
-      const {
-        payload: { repository },
-      } = github.context;
+      const context = github.context;
 
       const octokit = new github.GitHub(githubToken);
       //part of test
       const { data: currentPulls } = await octokit.pulls.list({
-        owner: repository.owner.login,
-        repo: repository.name,
+        ...context.repo,
       });
       //create new branch from source branch and PR between new branch and target branch
 
-      const context = github.context;
       const {
         data: { object: { sha } }
       } = await octokit.git.getRef({
@@ -42,13 +38,12 @@ async function run() {
       core.setOutput("PULL_REQUEST_BRANCH", newBranch);
       if (!currentPull) {
         const { data: pullRequest } = await octokit.pulls.create({
-          owner: repository.owner.login,
-          repo: repository.name,
           head: newBranch,
           base: branch,
           title: `sync: ${branch}  with ${newBranch}`,
           body: `sync-branches: syncing branch with ${newBranch}`,
           draft: false,
+          ...context.repo,
         });
 
         console.log(


### PR DESCRIPTION
Fixes #40 

Instead of using `context.sha` to create the branch, use the branch defined in `SOURCE_BRANCH`.